### PR TITLE
fix tagging action

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
   tag_release:
-    if: ${{ github.env.SKIP == 'false' }}
+    if: ${{ !contains(github.event.head_commit.message, '#skip') }}
     needs: [deploy]
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
bump version tag on each push to main
previously the action was broken (referring to a non-existing env)